### PR TITLE
Make the release tag trigger fire, and ship the CLI with it

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -171,3 +171,48 @@ jobs:
         with:
           name: coverage-report
           path: CoverageReport/
+
+  # The release ships a self-contained linux-x64 `mlqt`, and the tool package it also ships is
+  # framework-dependent, so both run on Linux. Nothing here ever tested that: every other job is
+  # windows-latest, so "the CLI works on Linux" was a claim held up by one person trying it once.
+  cli-linux:
+    name: CLI on Linux
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup .NET 10
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '10.0.x'
+          dotnet-quality: 'preview'
+
+      # Project by project rather than the solution: MLQT.slnx contains the MAUI app, whose workload
+      # does not exist on Linux. The CLI and everything beneath it are plain net10.0.
+      - name: Build the CLI and its tests
+        run: |
+          dotnet build MLQT.Cli/MLQT.Cli.csproj -c Release
+          dotnet build MLQT.Cli.Tests/MLQT.Cli.Tests.csproj -c Release
+
+      - name: Run CLI tests
+        run: dotnet test MLQT.Cli.Tests -c Release --no-build --logger "trx;LogFileName=cli-linux.trx" --results-directory ${{ github.workspace }}/TestResults
+
+      # Produce and run the exact artifact the release ships, against the committed fixture, so a
+      # release cannot be the first time that binary is built or executed on Linux. The check's exit
+      # code depends on the fixture's severities and is not what this asserts - that a report came
+      # out is.
+      - name: Publish and smoke-test the self-contained linux-x64 build
+        run: |
+          dotnet publish MLQT.Cli/MLQT.Cli.csproj -c Release -r linux-x64 --self-contained true -p:PublishSingleFile=false -o publish/mlqt-linux-x64
+          chmod +x publish/mlqt-linux-x64/mlqt
+          ./publish/mlqt-linux-x64/mlqt --version
+          ./publish/mlqt-linux-x64/mlqt check TestFixtures/SarifSmoke/Libraries/Smoke --format json --out smoke.json || true
+          test -s smoke.json
+
+      - name: Upload test results
+        uses: actions/upload-artifact@v6
+        if: always()
+        with:
+          name: test-results-linux
+          path: ${{ github.workspace }}/TestResults/*.trx

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,13 @@ name: Release
 on:
   push:
     tags:
-      - 'v*'  # Triggered by pushing a tag like v1.0.0
+      # Both spellings, because this repository uses the second one. Every release so far has been
+      # tagged bare (2026.1.0 ... 2026.3.1), which the 'v*' pattern does not match - so the tag
+      # trigger had never once fired, and each release was cut by dispatching this workflow by hand
+      # and attaching its artifacts to a release created separately. 'v*' is kept so an existing
+      # habit does not silently stop working.
+      - 'v*'
+      - '[0-9]*'
   workflow_dispatch:
     inputs:
       version:
@@ -54,6 +60,10 @@ jobs:
           dotnet test RevisionControl.Tests -c Release --no-restore --filter "FullyQualifiedName!~Svn"
           dotnet test MLQT.Services.Tests -c Release --no-restore
           dotnet test MLQT.McpServer.Tests -c Release --no-restore
+          # The CLI is a shipped artifact of this workflow, so it is tested by it. It was absent
+          # while it was only built here; now that the release packs and publishes the tool, a
+          # release could otherwise ship an `mlqt` that no step in this workflow ever ran.
+          dotnet test MLQT.Cli.Tests -c Release --no-restore
 
       # Stage the SlikSVN command-line client into MLQT/svn-tools/win-x64 so the publish
       # step (via MLQT.csproj) copies it into the app output under svn/. The zip URL is
@@ -99,6 +109,28 @@ jobs:
           -p:PublishSingleFile=false
           -o publish/MLQT.McpServer
 
+      # The CLI is a `dotnet tool` (PackageId MLQT.Cli, command `mlqt`), which is how
+      # Documentation/cli.md tells people to install it - so a release that did not carry the package
+      # left those instructions with nothing to install from. Packed at the release's version rather
+      # than the 0.1.0 in the csproj, so the tool and the app a user downloads say the same thing.
+      - name: Pack the mlqt CLI tool
+        run: >
+          dotnet pack MLQT.Cli/MLQT.Cli.csproj
+          -c Release
+          -p:Version=${{ steps.version.outputs.version }}
+          -o publish/nupkg
+
+      # Same reasoning as the bundled svn client: fail here rather than publish a release whose
+      # documented install command has no package behind it.
+      - name: Verify the CLI package
+        shell: pwsh
+        run: |
+          $nupkg = "publish/nupkg/MLQT.Cli.${{ steps.version.outputs.version }}.nupkg"
+          if (-not (Test-Path $nupkg)) {
+            throw "Expected $nupkg. Check the pack step and MLQT.Cli's PackageId/Version."
+          }
+          Write-Host "CLI package OK: $nupkg"
+
       - name: Create zip archives
         shell: pwsh
         run: |
@@ -112,13 +144,16 @@ jobs:
           path: |
             MLQT-${{ steps.version.outputs.version }}-win-x64.zip
             MLQT.McpServer-${{ steps.version.outputs.version }}-win-x64.zip
+            publish/nupkg/MLQT.Cli.${{ steps.version.outputs.version }}.nupkg
 
+      # Any tag, not only 'v'-prefixed ones - see the trigger above for why that mattered.
       - name: Create GitHub Release
-        if: startsWith(github.ref, 'refs/tags/v')
+        if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v2
         with:
           files: |
             MLQT-${{ steps.version.outputs.version }}-win-x64.zip
             MLQT.McpServer-${{ steps.version.outputs.version }}-win-x64.zip
+            publish/nupkg/MLQT.Cli.${{ steps.version.outputs.version }}.nupkg
           generate_release_notes: true
           draft: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,6 +113,11 @@ jobs:
       # Documentation/cli.md tells people to install it - so a release that did not carry the package
       # left those instructions with nothing to install from. Packed at the release's version rather
       # than the 0.1.0 in the csproj, so the tool and the app a user downloads say the same thing.
+      #
+      # This package is framework-dependent and carries no runtime identifier, so it is already the
+      # Linux and macOS build as well as the Windows one: MLQT.Cli targets plain net10.0 and nothing
+      # in its dependency chain is Windows-only. The linux-x64 archive below is not a second package
+      # for a platform this one misses - it is for machines with no .NET 10 runtime to install into.
       - name: Pack the mlqt CLI tool
         run: >
           dotnet pack MLQT.Cli/MLQT.Cli.csproj
@@ -131,6 +136,28 @@ jobs:
           }
           Write-Host "CLI package OK: $nupkg"
 
+      # A self-contained linux-x64 `mlqt` for machines with no .NET 10 runtime - a CI agent or a
+      # container where installing one is not wanted. Cross-published from this Windows runner, which
+      # needs no Linux toolchain: the output is managed code plus the runtime's own native libraries.
+      - name: Publish the mlqt CLI (self-contained linux-x64)
+        run: >
+          dotnet publish MLQT.Cli/MLQT.Cli.csproj
+          -c Release
+          -r linux-x64
+          --self-contained true
+          -p:PublishSingleFile=false
+          -p:Version=${{ steps.version.outputs.version }}
+          -o publish/mlqt-linux-x64
+
+      # tar, not zip: it preserves the executable bit on `mlqt`, which a zip does not, so the file a
+      # user extracts is one they can run without being told to chmod it first.
+      - name: Archive the Linux CLI
+        shell: bash
+        run: |
+          test -f publish/mlqt-linux-x64/mlqt || { echo "no mlqt binary in the linux-x64 publish"; exit 1; }
+          chmod +x publish/mlqt-linux-x64/mlqt
+          tar -czf "mlqt-${{ steps.version.outputs.version }}-linux-x64.tar.gz" -C publish/mlqt-linux-x64 .
+
       - name: Create zip archives
         shell: pwsh
         run: |
@@ -145,6 +172,7 @@ jobs:
             MLQT-${{ steps.version.outputs.version }}-win-x64.zip
             MLQT.McpServer-${{ steps.version.outputs.version }}-win-x64.zip
             publish/nupkg/MLQT.Cli.${{ steps.version.outputs.version }}.nupkg
+            mlqt-${{ steps.version.outputs.version }}-linux-x64.tar.gz
 
       # Any tag, not only 'v'-prefixed ones - see the trigger above for why that mattered.
       - name: Create GitHub Release
@@ -155,5 +183,6 @@ jobs:
             MLQT-${{ steps.version.outputs.version }}-win-x64.zip
             MLQT.McpServer-${{ steps.version.outputs.version }}-win-x64.zip
             publish/nupkg/MLQT.Cli.${{ steps.version.outputs.version }}.nupkg
+            mlqt-${{ steps.version.outputs.version }}-linux-x64.tar.gz
           generate_release_notes: true
           draft: true

--- a/Documentation/cli.md
+++ b/Documentation/cli.md
@@ -10,12 +10,14 @@ works on Windows, Linux, and macOS and is suited to CI pipelines.
 
 ## Install
 
-Packaged as a .NET tool:
+Packaged as a .NET tool. The package is **not on nuget.org**: download
+`MLQT.Cli.<version>.nupkg` from the [latest release](https://github.com/mdempse1/MLQT/releases) and
+install it from the directory you saved it in, which is what `--add-source .` below means.
 
 ```bash
-dotnet tool install --global MLQT.Cli      # provides the `mlqt` command
+dotnet tool install --global --add-source . MLQT.Cli      # provides the `mlqt` command
 # or into an isolated location:
-dotnet tool install --tool-path ./tools MLQT.Cli
+dotnet tool install --tool-path ./tools --add-source . MLQT.Cli
 ```
 
 Requires the .NET 10 runtime.

--- a/Documentation/cli.md
+++ b/Documentation/cli.md
@@ -10,9 +10,12 @@ works on Windows, Linux, and macOS and is suited to CI pipelines.
 
 ## Install
 
-Packaged as a .NET tool. The package is **not on nuget.org**: download
-`MLQT.Cli.<version>.nupkg` from the [latest release](https://github.com/mdempse1/MLQT/releases) and
-install it from the directory you saved it in, which is what `--add-source .` below means.
+Two ways, depending on whether the machine has a .NET 10 runtime.
+
+**As a .NET tool** (Windows, Linux and macOS — one package covers all three). It is **not on
+nuget.org**: download `MLQT.Cli.<version>.nupkg` from the
+[latest release](https://github.com/mdempse1/MLQT/releases) and install it from the directory you
+saved it in, which is what `--add-source .` means below.
 
 ```bash
 dotnet tool install --global --add-source . MLQT.Cli      # provides the `mlqt` command
@@ -21,6 +24,16 @@ dotnet tool install --tool-path ./tools --add-source . MLQT.Cli
 ```
 
 Requires the .NET 10 runtime.
+
+**As a self-contained Linux binary**, for a build agent or container where you would rather not
+install .NET. Download `mlqt-<version>-linux-x64.tar.gz` from the same release:
+
+```bash
+tar -xzf mlqt-<version>-linux-x64.tar.gz -C /opt/mlqt && /opt/mlqt/mlqt --version
+```
+
+It carries its own runtime, so it needs nothing preinstalled. Put the directory on your `PATH`, or
+call the binary by full path.
 
 ## Usage
 

--- a/MLQT.Cli.Tests/ReviewFindingFormatterTests.cs
+++ b/MLQT.Cli.Tests/ReviewFindingFormatterTests.cs
@@ -14,7 +14,12 @@ namespace MLQT.Cli.Tests;
 /// </summary>
 public class ReviewFindingFormatterTests
 {
-    private const string Repo = @"C:\repo";
+    // Absolute on whichever OS is running the test. A Windows-shaped literal is a *relative* path
+    // on Linux, and ClassLocation normalises what it is handed with Path.GetFullPath - so on Linux
+    // the locations under test resolved against the working directory while this fixture's own diff
+    // keys did not, nothing matched, and every "this is commented" assertion failed while passing
+    // on Windows.
+    private static readonly string Repo = OperatingSystem.IsWindows() ? @"C:\repo" : "/repo";
     private static readonly string LibraryFile = Path.Combine(Repo, "Lib", "package.mo");
 
     private static Finding Finding(
@@ -36,7 +41,10 @@ public class ReviewFindingFormatterTests
         new(true, Repo,
             new Dictionary<string, IReadOnlySet<int>>(StringComparer.OrdinalIgnoreCase)
             {
-                [LibraryFile] = new HashSet<int>(lines)
+                // Keyed as GitRevisionControlSystem keys the real thing - GetFullPath over the
+                // repository root joined to the diff's relative path - so the fixture cannot drift
+                // from the normalisation applied to the paths it is compared against.
+                [Path.GetFullPath(LibraryFile)] = new HashSet<int>(lines)
             },
             null);
 

--- a/README.md
+++ b/README.md
@@ -115,7 +115,9 @@ dotnet test MLQT.McpServer.Tests
 
 ## Continuous Integration
 
-GitHub Actions workflows run automatically on pushes to `main`/`develop` and on pull requests:
+GitHub Actions workflows run automatically on a push to **any** branch and on pull requests to
+`main` — deliberately every branch, so a long-lived working branch does not reach its first CI run
+at the moment it is being merged:
 
 - **Build & Test** — Builds all library and test projects, runs all test suites, uploads test results as artifacts
 - **Build MAUI App** — Verifies the Windows desktop application builds successfully
@@ -139,6 +141,12 @@ These tests should be run locally when making changes to the affected projects.
 DymolaInterface and OpenModelicaInterface are excluded from CI coverage reports since they cannot be tested without their respective tools installed.
 
 RevisionControl coverage will appear low in CI reports because the SVN integration tests are excluded (they require a local SVN repository). The full test suite, including SVN tests, should be run locally to verify actual coverage meets the >80% target.
+
+## Releasing
+
+Tag `main` and the Release workflow builds the desktop app, the MCP server and the `mlqt` CLI
+package, then opens a draft release with all three attached. See [RELEASING.md](RELEASING.md) for the
+version scheme, the dry-run route, and what to check before tagging.
 
 ## Architecture Overview
 

--- a/README.md
+++ b/README.md
@@ -122,6 +122,8 @@ at the moment it is being merged:
 - **Build & Test** — Builds all library and test projects, runs all test suites, uploads test results as artifacts
 - **Build MAUI App** — Verifies the Windows desktop application builds successfully
 - **Code Coverage** — Runs tests with coverage collection and generates a summary report
+- **CLI on Linux** — Builds and tests the `mlqt` CLI on Ubuntu, then produces and runs the
+  self-contained `linux-x64` binary the release ships
 
 ### What isn't tested in CI
 
@@ -144,9 +146,10 @@ RevisionControl coverage will appear low in CI reports because the SVN integrati
 
 ## Releasing
 
-Tag `main` and the Release workflow builds the desktop app, the MCP server and the `mlqt` CLI
-package, then opens a draft release with all three attached. See [RELEASING.md](RELEASING.md) for the
-version scheme, the dry-run route, and what to check before tagging.
+Tag `main` and the Release workflow builds the desktop app, the MCP server, the `mlqt` CLI tool
+package and a self-contained Linux CLI binary, then opens a draft release with all four attached. See
+[RELEASING.md](RELEASING.md) for the version scheme, the dry-run route, and what to check before
+tagging.
 
 ## Architecture Overview
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,86 @@
+# Releasing MLQT
+
+Maintainer-facing. `.github/workflows/release.yml` does the work; this says what it produces, how to
+set it off, and what has caught people out.
+
+## What a release contains
+
+Three assets, all stamped with the release version:
+
+| Asset | What it is | Built by |
+|-------|------------|----------|
+| `MLQT-<version>-win-x64.zip` | The desktop app, self-contained, with the SlikSVN command-line client bundled under `svn/` | `dotnet publish MLQT/MLQT.csproj` |
+| `MLQT.McpServer-<version>-win-x64.zip` | The headless MCP server, self-contained | `dotnet publish MLQT.McpServer/MLQT.McpServer.csproj` |
+| `MLQT.Cli.<version>.nupkg` | The `mlqt` CLI, as a .NET tool package | `dotnet pack MLQT.Cli/MLQT.Cli.csproj` |
+
+Only the CLI is a NuGet package, and only because it is a `dotnet tool`. The MCP server is a plain
+executable on purpose: an MCP client launches it by absolute path, which is what
+[mcp-server.md](Documentation/mcp-server.md) documents for both the built output and the release zip.
+Packaging it would give it a `dotnet tool` install nothing asks for.
+
+Neither package goes to a public feed. Users install the CLI from the release with `--add-source`, as
+[cli.md](Documentation/cli.md) describes.
+
+## Versioning
+
+Tags are bare `YYYY.N.P` — `2026.1.0`, `2026.3.0`, `2026.3.1`, `2026.4.0`. **No `v` prefix.**
+
+The tag *is* the version. It becomes `ApplicationDisplayVersion` on the desktop app and the package
+version of the CLI, overriding the `<Version>` in `MLQT.Cli.csproj` — so that number is not bumped by
+hand and does not need to track releases.
+
+## Cutting one
+
+1. Check that `main` is green — Build and Test on the exact commit you are releasing.
+2. Tag it and push the tag:
+
+   ```bash
+   git tag 2026.4.0
+   ```
+
+   ```bash
+   git push origin 2026.4.0
+   ```
+
+3. The Release workflow runs the test suites, bundles the SVN client, publishes the app and the MCP
+   server, packs the CLI, and fails loudly if either the bundled `svn.exe` or the CLI package is
+   missing from the output.
+4. It opens a **draft** release with generated notes and the three assets attached. Review it and
+   publish.
+
+## Dry runs
+
+The workflow also takes a manual `workflow_dispatch` with a version input, from the Actions tab or:
+
+```bash
+gh workflow run release.yml -f version=2026.4.0 --ref main
+```
+
+That builds and uploads the same three assets as a *workflow artifact*, but does **not** create a
+release — the release step runs only for a tag. It is the way to prove a release will build without
+committing to one.
+
+## Before you tag
+
+- The `SLIKSVN_ZIP_URL` repository variable (Settings → Secrets and variables → Actions → Variables)
+  must point at a SlikSVN 1.14+ x64 `.zip`, or the bundling step fails.
+- If what the release ships changes, `Documentation/cli.md` and `Documentation/mcp-server.md` change
+  with it — they tell users how to install these artifacts, and a release that ships something the
+  docs do not describe is a release nobody can use.
+
+## What bit people before
+
+Releases 2026.1.0 through 2026.3.1 were cut by hand, and not by choice: the trigger matched `v*`
+while every tag was bare, so pushing a tag started nothing at all, and the release-creation step was
+gated on the same pattern. Each release was made by dispatching the workflow and attaching its
+artifacts to a release created separately — which looked like the process, and was really a bug
+being worked around. Fixed for 2026.4.0; both now accept a bare tag, and `v*` still works.
+
+If you ever find yourself uploading zips by hand again, that is the symptom, not the process.
+
+## Deliberately not automated
+
+- **Publishing the CLI to nuget.org.** Needs a `NUGET_API_KEY` secret and a decision about public
+  distribution. Until then the `.nupkg` on the release is the distribution.
+- **Anything but win-x64.** The desktop app is MAUI/Windows today; see
+  [Design/design-phase7-gui-tests.md](Design/design-phase7-gui-tests.md) for where that is heading.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -5,18 +5,27 @@ set it off, and what has caught people out.
 
 ## What a release contains
 
-Three assets, all stamped with the release version:
+Four assets, all stamped with the release version:
 
 | Asset | What it is | Built by |
 |-------|------------|----------|
 | `MLQT-<version>-win-x64.zip` | The desktop app, self-contained, with the SlikSVN command-line client bundled under `svn/` | `dotnet publish MLQT/MLQT.csproj` |
 | `MLQT.McpServer-<version>-win-x64.zip` | The headless MCP server, self-contained | `dotnet publish MLQT.McpServer/MLQT.McpServer.csproj` |
-| `MLQT.Cli.<version>.nupkg` | The `mlqt` CLI, as a .NET tool package | `dotnet pack MLQT.Cli/MLQT.Cli.csproj` |
+| `MLQT.Cli.<version>.nupkg` | The `mlqt` CLI, as a .NET tool package — Windows, Linux **and** macOS | `dotnet pack MLQT.Cli/MLQT.Cli.csproj` |
+| `mlqt-<version>-linux-x64.tar.gz` | The CLI as a self-contained Linux binary, carrying its own runtime | `dotnet publish MLQT.Cli/MLQT.Cli.csproj -r linux-x64` |
 
 Only the CLI is a NuGet package, and only because it is a `dotnet tool`. The MCP server is a plain
 executable on purpose: an MCP client launches it by absolute path, which is what
 [mcp-server.md](Documentation/mcp-server.md) documents for both the built output and the release zip.
 Packaging it would give it a `dotnet tool` install nothing asks for.
+
+**There is no separate Linux package, and none is needed.** `MLQT.Cli` targets plain `net10.0` with
+no runtime identifier and nothing Windows-only beneath it, so the one `.nupkg` installs and runs on
+all three platforms. The `linux-x64` tarball is not a second package filling a gap — it exists only
+for machines where you would rather not install a .NET runtime at all. If you find yourself adding a
+per-platform *package*, check that assumption first.
+
+The desktop app and MCP server remain win-x64 only.
 
 Neither package goes to a public feed. Users install the CLI from the release with `--add-source`, as
 [cli.md](Documentation/cli.md) describes.
@@ -43,9 +52,9 @@ hand and does not need to track releases.
    ```
 
 3. The Release workflow runs the test suites, bundles the SVN client, publishes the app and the MCP
-   server, packs the CLI, and fails loudly if either the bundled `svn.exe` or the CLI package is
-   missing from the output.
-4. It opens a **draft** release with generated notes and the three assets attached. Review it and
+   server, packs the CLI, cross-publishes the Linux CLI binary, and fails loudly if the bundled
+   `svn.exe`, the CLI package or the Linux binary is missing from the output.
+4. It opens a **draft** release with generated notes and all four assets attached. Review it and
    publish.
 
 ## Dry runs
@@ -56,7 +65,7 @@ The workflow also takes a manual `workflow_dispatch` with a version input, from 
 gh workflow run release.yml -f version=2026.4.0 --ref main
 ```
 
-That builds and uploads the same three assets as a *workflow artifact*, but does **not** create a
+That builds and uploads the same four assets as a *workflow artifact*, but does **not** create a
 release — the release step runs only for a tag. It is the way to prove a release will build without
 committing to one.
 
@@ -82,5 +91,9 @@ If you ever find yourself uploading zips by hand again, that is the symptom, not
 
 - **Publishing the CLI to nuget.org.** Needs a `NUGET_API_KEY` secret and a decision about public
   distribution. Until then the `.nupkg` on the release is the distribution.
-- **Anything but win-x64.** The desktop app is MAUI/Windows today; see
-  [Design/design-phase7-gui-tests.md](Design/design-phase7-gui-tests.md) for where that is heading.
+- **Anything but win-x64, for the desktop app and MCP server.** Both are MAUI/Windows-shaped today;
+  see [Design/design-phase7-gui-tests.md](Design/design-phase7-gui-tests.md) for where that is
+  heading. The CLI is already cross-platform and is built and tested on Linux by the `CLI on Linux`
+  job in `build-and-test.yml`, which also produces and runs the tarball the release ships.
+- **macOS and arm64 binaries.** The tool package covers those machines when a .NET 10 runtime is
+  present; only linux-x64 gets a self-contained build, because that is where the CI agents are.


### PR DESCRIPTION
Preparation for the 2026.4.0 release, which is the first to ship the `mlqt` CLI.

## The tag trigger has never fired

`release.yml` triggers on `tags: ['v*']`, but every release so far has been tagged bare — `2026.1.0` through `2026.3.1`. Pushing a tag started nothing. The `Create GitHub Release` step was gated on `refs/tags/v` for the same reason, so it had never run either, and each release was cut by dispatching the workflow by hand and attaching its artifacts to a release created separately.

Both now accept a bare tag. `v*` is kept so the other spelling does not silently stop working. `${GITHUB_REF_NAME#v}` already handles a tag without the prefix, so the version comes out right either way.

After this, cutting a release is `git tag 2026.4.0 && git push origin 2026.4.0`, which produces a **draft** release for review.

## The CLI is packed and shipped

`MLQT.Cli` is a `dotnet tool` (`PackageId` `MLQT.Cli`, command `mlqt`) and `Documentation/cli.md` tells people to install it — but nothing packed it, so those instructions had no package behind them.

- Packed at the release's version rather than the `0.1.0` in the csproj, so the tool and the app say the same thing.
- Verified to exist before the release is created, in the same spirit as the existing bundled-svn check.
- Attached to the release and the workflow artifact.
- `Documentation/cli.md` now says to install it from the release with `--add-source`, since it is not on nuget.org and the old wording implied it was.

## `MLQT.Cli.Tests` runs in this workflow

It was omitted while the CLI was only built here. Now that the workflow ships the tool, a release could otherwise deliver an `mlqt` that nothing in this workflow had run.

## Verified

- Workflow YAML parses; triggers resolve to `['v*', '[0-9]*']`.
- `dotnet pack MLQT.Cli/MLQT.Cli.csproj -c Release -p:Version=2026.4.0` produces exactly `MLQT.Cli.2026.4.0.nupkg` — the filename the verify step and the release assets expect.

Not addressed here: publishing to nuget.org, which needs an API key secret and is a separate decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Added: the release process is written down

`RELEASING.md` (linked from the README) records what nothing in the repository did: what a release contains, how to cut one, and the trap above — a process that had been worked around by hand for four releases without anyone asking why the tag did nothing.

It covers which of the three assets is a package and why, the bare `YYYY.N.P` tag scheme and the fact that the tag versions every asset, the `workflow_dispatch` dry run, what to check before tagging, and what is deliberately left manual (nuget.org publishing, non-win-x64 builds).

Also fixed one stale claim in the README's CI section: it said the workflows run on pushes to `main`/`develop`. There is no `develop` branch, and the trigger has been every branch since the CI/CD work.


---

## Added: Linux for the CLI

Confirmed working on Ubuntu by hand, so the repository now holds it.

**There is no second package to add.** `MLQT.Cli` targets plain `net10.0` with no runtime identifier, and nothing in its dependency chain is Windows-only (`RevisionControl`'s LibGit2Sharp is the closest thing, and ships its own Linux natives). The `.nupkg` this PR already added installs and runs on Linux and macOS as it stands — a per-platform package would have been a second copy of the same artifact. `RELEASING.md` says so where someone would go looking.

**What was missing** is a build for machines with no .NET 10 runtime — most CI agents and containers. The release now cross-publishes a self-contained `linux-x64` `mlqt` and ships `mlqt-<version>-linux-x64.tar.gz`. `tar` rather than `zip` so the executable bit survives extraction.

**And a Linux CI job.** Every job in this repo was `windows-latest`, so shipping a Linux artifact would have rested "the CLI works on Linux" on one person having tried it once. `CLI on Linux` builds the CLI and its tests on `ubuntu-latest`, runs the 295 tests, then produces the exact self-contained binary the release ships and runs it against the committed SARIF fixture. It builds project by project rather than via `MLQT.slnx`, which contains the MAUI app and its Windows-only workload.

### Assets after this PR

| Asset | Platforms |
|---|---|
| `MLQT-<v>-win-x64.zip` | Windows |
| `MLQT.McpServer-<v>-win-x64.zip` | Windows |
| `MLQT.Cli.<v>.nupkg` | Windows, Linux, macOS (needs .NET 10) |
| `mlqt-<v>-linux-x64.tar.gz` | Linux, no runtime needed |

### Verified locally

- Cross-publish from Windows produces a real Linux binary: `ELF 64-bit LSB pie executable, x86-64 ... dynamically linked`.
- The smoke-test commands (`--version`, and `check <fixture> --format json --out`) both run and produce a report.
- Both workflow files parse; `build-and-test.yml` resolves to four jobs.

Not verified locally: that `MLQT.Cli.Tests` passes on Ubuntu — this PR's CI run is the first time that has ever been tried.
