### PR TITLE
Give the release job permission to create the release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,14 @@ jobs:
     name: Build & Publish Release
     runs-on: windows-latest
 
+    # Creating the release and uploading its assets is a write, and this repository's default workflow
+    # token is read-only, so the step failed with a 403 the first time it ever ran - which was the
+    # first tag-triggered release, because the trigger itself had never fired before. Declared here
+    # rather than by making the repository-wide default read/write: only this job writes anything,
+    # and a setting in the web UI is not visible to anyone reading this file.
+    permissions:
+      contents: write
+
     steps:
       - uses: actions/checkout@v6
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -87,6 +87,32 @@ being worked around. Fixed for 2026.4.0; both now accept a bare tag, and `v*` st
 
 If you ever find yourself uploading zips by hand again, that is the symptom, not the process.
 
+There was a second bug hiding behind the first, and it could only be reached once the first was
+fixed. The very first tag that did fire built everything and then failed on the last step with
+`403 Resource not accessible by integration`: creating a release is a write, this repository's
+default workflow token is read-only, and no run had ever reached that step to find out. The job now
+declares `permissions: contents: write`. Nothing had been published when it failed, so the fix was to
+move the tag — see below.
+
+## When a release run fails
+
+**The workflow that runs for a tag is the one committed at that tag**, not the one on `main`. So
+fixing `release.yml` on `main` does nothing for an existing tag: re-running the failed run replays the
+old file and fails the same way. The tag has to move to a commit that contains the fix.
+
+Provided nothing was published — check with `gh release list` before assuming — that is:
+
+```bash
+git push origin :refs/tags/2026.4.0        # delete the remote tag
+```
+
+```bash
+git tag -d 2026.4.0 && git tag 2026.4.0 && git push origin 2026.4.0
+```
+
+Re-pointing a tag is only safe while no release exists behind it and nobody has pulled it. Once a
+release is published, the tag is part of the record: fix forward with a new patch version instead.
+
 ## Deliberately not automated
 
 - **Publishing the CLI to nuget.org.** Needs a `NUGET_API_KEY` secret and a decision about public


### PR DESCRIPTION
The `2026.4.0` tag fired the release workflow correctly — the trigger fix works — and it built every asset before failing on the last step:

```
⚠️ GitHub release failed with status: 403
{"message":"Resource not accessible by integration", ...}
```

The Node 20 deprecation warning in the same log is unrelated: `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` already forces the action onto Node 24, and it ran fine.

## Cause

Creating a release and uploading its assets is a write. `default_workflow_permissions` on this repository is `read`, and neither workflow declared a `permissions:` block, so `softprops/action-gh-release` had no rights to do it.

This was hidden behind the bug PR #4 fixed. The tag trigger had never fired in the repository's history, and the `Create GitHub Release` step was gated on the same `v*` pattern — so that step had **never run once**. Every previous release was created by a human with their own token. Fixing the trigger is what exposed the second bug.

## Fix

`permissions: contents: write`, declared on the job rather than by flipping the repository-wide default to read/write: only this job writes anything, and a setting in the web UI is invisible to whoever next reads this file.

## Also documented

`RELEASING.md` gains the thing this made obvious, which matters for recovering from any failed release: **the workflow that runs for a tag is the one committed at that tag**, not the one on `main`. Re-running the failed run replays the old file. The tag has to move — with the caveat that re-pointing a tag is only safe while nothing has been published behind it, which is the case here (`gh release list` shows no `2026.4.0`, not even a draft).

🤖 Generated with [Claude Code](https://claude.com/claude-code)