### PR TITLE
Add SpawnEnvironmentVariables to DymolaInterface

### DIFF
--- a/DymolaInterface.Tests/SpawnEnvironmentTests.cs
+++ b/DymolaInterface.Tests/SpawnEnvironmentTests.cs
@@ -1,0 +1,75 @@
+using System.Diagnostics;
+using System.Reflection;
+using Xunit;
+
+namespace DymolaInterface.Tests;
+
+/// <summary>
+/// Tests for <see cref="DymolaInterface.SpawnEnvironmentVariables"/>. The start info is
+/// built by a private method; reflection is used to inspect it without launching a
+/// process, following the same approach as <see cref="Fakes.DymolaTestHarness"/>.
+/// </summary>
+public class SpawnEnvironmentTests
+{
+    private static ProcessStartInfo CreateStartInfo(DymolaInterface dymola)
+    {
+        var method = typeof(DymolaInterface).GetMethod("CreateStartInfo",
+            BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("CreateStartInfo method not found");
+        return (ProcessStartInfo)method.Invoke(dymola, null)!;
+    }
+
+    [Fact]
+    public void SpawnEnvironmentVariables_DefaultsToNull()
+    {
+        using var dymola = new DymolaInterface("", 9999, "127.0.0.1");
+
+        Assert.Null(dymola.SpawnEnvironmentVariables);
+    }
+
+    [Fact]
+    public void CreateStartInfo_WithoutSpawnEnvironment_UsesInheritedEnvironmentOnly()
+    {
+        using var dymola = new DymolaInterface("C:/Dymola/bin64/Dymola.exe", 9999, "127.0.0.1");
+
+        var startInfo = CreateStartInfo(dymola);
+
+        Assert.Equal("C:/Dymola/bin64/Dymola.exe", startInfo.FileName);
+        Assert.Equal("-serverport 9999", startInfo.Arguments);
+        Assert.False(startInfo.UseShellExecute);
+        Assert.True(startInfo.CreateNoWindow);
+    }
+
+    [Fact]
+    public void CreateStartInfo_WithSpawnEnvironment_AddsVariables()
+    {
+        using var dymola = new DymolaInterface("C:/Dymola/bin64/Dymola.exe", 9999, "127.0.0.1")
+        {
+            SpawnEnvironmentVariables = new Dictionary<string, string>
+            {
+                ["TMP"] = @"C:\Users\test\AppData\Local\Temp",
+                ["SALT_LICENSE_SERVER"] = "27000@licenses.example.com"
+            }
+        };
+
+        var startInfo = CreateStartInfo(dymola);
+
+        Assert.Equal(@"C:\Users\test\AppData\Local\Temp", startInfo.Environment["TMP"]);
+        Assert.Equal("27000@licenses.example.com", startInfo.Environment["SALT_LICENSE_SERVER"]);
+    }
+
+    [Fact]
+    public void CreateStartInfo_WithSpawnEnvironment_OverridesInheritedValue()
+    {
+        var inheritedName = Environment.GetEnvironmentVariables().Keys.Cast<string>()
+            .First(k => !string.IsNullOrEmpty(k) && !k.StartsWith('='));
+        using var dymola = new DymolaInterface("C:/Dymola/bin64/Dymola.exe", 9999, "127.0.0.1")
+        {
+            SpawnEnvironmentVariables = new Dictionary<string, string> { [inheritedName] = "overridden" }
+        };
+
+        var startInfo = CreateStartInfo(dymola);
+
+        Assert.Equal("overridden", startInfo.Environment[inheritedName]);
+    }
+}

--- a/DymolaInterface/DymolaInterface.cs
+++ b/DymolaInterface/DymolaInterface.cs
@@ -58,6 +58,14 @@ public class DymolaInterface : IDisposable
         _isOffline = !IsDymolaRunning();
     }
 
+    /// <summary>
+    /// Extra environment variables applied to the Dymola process launched by
+    /// <see cref="StartDymolaProcessAsync"/>, on top of the environment inherited from
+    /// this process. Entries override inherited values. Has no effect on a Dymola that
+    /// is already running when this interface connects to it.
+    /// </summary>
+    public IReadOnlyDictionary<string, string>? SpawnEnvironmentVariables { get; set; }
+
     #region Process management
 
     public async Task StartDymolaProcessAsync()
@@ -71,15 +79,7 @@ public class DymolaInterface : IDisposable
         await _commandLock.WaitAsync();
         try
         {
-            var startInfo = new ProcessStartInfo
-            {
-                FileName = _dymolaPath,
-                Arguments = $"-serverport {_portNumber}",
-                UseShellExecute = false,
-                CreateNoWindow = true
-            };
-
-            _dymolaProcess = Process.Start(startInfo);
+            _dymolaProcess = Process.Start(CreateStartInfo());
 
             for (int i = 0; i < 30; i++)
             {
@@ -97,6 +97,23 @@ public class DymolaInterface : IDisposable
         {
             _commandLock.Release();
         }
+    }
+
+    private ProcessStartInfo CreateStartInfo()
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = _dymolaPath,
+            Arguments = $"-serverport {_portNumber}",
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+
+        if (SpawnEnvironmentVariables != null)
+            foreach (var pair in SpawnEnvironmentVariables)
+                startInfo.Environment[pair.Key] = pair.Value;
+
+        return startInfo;
     }
 
     public async Task StopDymolaProcessAsync()

--- a/DymolaInterface/README.md
+++ b/DymolaInterface/README.md
@@ -55,6 +55,15 @@ var dymola = new DymolaInterface(
     portNumber: 8082,
     hostname: "127.0.0.1"
 );
+
+// Optional: extra environment variables for the spawned Dymola process. Entries are
+// applied on top of the inherited environment and override it; they have no effect
+// when connecting to a Dymola that is already running.
+dymola.SpawnEnvironmentVariables = new Dictionary<string, string>
+{
+    ["SALT_LICENSE_SERVER"] = "27000@licenses.example.com"
+};
+
 await dymola.StartDymolaProcessAsync();
 
 try


### PR DESCRIPTION
MCP hosts launch servers with a stripped environment and a spawned Dymola inherits it - notably TMP is missing, which breaks the licensing of encrypted Claytex libraries (DAT-27). The property lets the caller apply extra environment variables to the process started by StartDymolaProcessAsync; entries override inherited values and have no effect when attaching to an already-running Dymola. The Dymola MCP servers use it to repair the spawned environment and to expose an env passthrough on start_dymola.