### PR TITLE
Add ProcessId to DymolaInterface

### DIFF
--- a/DymolaInterface.Tests/DymolaInterfaceTests.cs
+++ b/DymolaInterface.Tests/DymolaInterfaceTests.cs
@@ -99,4 +99,31 @@ public class DymolaInterfaceTests
         // Assert
         Assert.False(isOffline);
     }
+
+    [Fact]
+    public void ProcessId_WhenNoProcessStarted_IsNull()
+    {
+        using var dymola = new DymolaInterface("", 9999, "127.0.0.1");
+
+        Assert.False(dymola.OwnsProcess);
+        Assert.Null(dymola.ProcessId);
+    }
+
+    [Fact]
+    public void ProcessId_AfterDetach_IsNull()
+    {
+        using var dymola = new DymolaInterface("", 9999, "127.0.0.1");
+
+        dymola.Detach();
+
+        Assert.Null(dymola.ProcessId);
+    }
+
+    [Fact]
+    public async Task ProcessId_HasValueExactlyWhenTheInterfaceOwnsTheProcess()
+    {
+        await _fixture.EnsureDymolaStartedAsync();
+
+        Assert.Equal(_fixture.Dymola.OwnsProcess, _fixture.Dymola.ProcessId.HasValue);
+    }
 }

--- a/DymolaInterface/DymolaInterface.cs
+++ b/DymolaInterface/DymolaInterface.cs
@@ -127,6 +127,21 @@ public class DymolaInterface : IDisposable
     public bool OwnsProcess => _dymolaProcess != null && !_dymolaProcess.HasExited;
 
     /// <summary>
+    /// OS process id of the Dymola this interface started, or null when it attached to a
+    /// Dymola some other process started, after <see cref="Detach"/>, or once the process
+    /// has exited. Lets a caller record which instances it is responsible for, so that a
+    /// later process can re-attach to them or reap them instead of leaking them.
+    /// </summary>
+    public int? ProcessId
+    {
+        get
+        {
+            var process = _dymolaProcess;
+            return process != null && !process.HasExited ? process.Id : null;
+        }
+    }
+
+    /// <summary>
     /// Relinquish ownership of the underlying Dymola process without terminating it.
     /// After Detach, <see cref="Dispose"/> / <see cref="StopDymolaProcessAsync"/> no
     /// longer kill the process, so the running Dymola survives this interface being


### PR DESCRIPTION
The wrapper holds the Dymola process it started privately and exposes no accessor, so a caller cannot record which instances it is responsible for. The Dymola MCP servers need that to recover from a client-side tool timeout (DAT-38): the MCP client kills the server mid-call, but the Dymola the server spawned is not the client's child and survives. Without its process id the next server process can neither name it in a diagnostic nor tell it apart from a Dymola the user opened themselves.

ProcessId mirrors OwnsProcess - non-null exactly when this interface started the process and it is still running, and null once it exits, after Detach, or when attached to an instance another process started.